### PR TITLE
Add RandomPosts component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # The Connect Game
 
 App to show random WordPress posts based on category selection.
+
+## Components
+
+### RandomPosts
+A React Native component that fetches random posts from the WordPress API and allows users to refresh the list.

--- a/src/components/RandomPosts.js
+++ b/src/components/RandomPosts.js
@@ -1,0 +1,72 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
+
+const POSTS_ENDPOINT = 'https://theconnectgame.com/wp-json/wp/v2/posts?per_page=10&orderby=rand';
+
+const RandomPosts = () => {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchPosts = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch(POSTS_ENDPOINT);
+      if (!response.ok) {
+        throw new Error('Failed to fetch posts');
+      }
+      const data = await response.json();
+      setPosts(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPosts();
+  }, [fetchPosts]);
+
+  return (
+    <View style={styles.container}>
+      <Button title="Refresh" onPress={fetchPosts} />
+      {loading && <Text style={styles.message}>Loading...</Text>}
+      {error && <Text style={styles.error}>{error}</Text>}
+      <FlatList
+        data={posts}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <View style={styles.postItem}>
+            <Text style={styles.title}>{item.title.rendered}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#fff',
+  },
+  postItem: {
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  message: {
+    marginVertical: 8,
+  },
+  error: {
+    color: 'red',
+    marginVertical: 8,
+  },
+});
+
+export default RandomPosts;


### PR DESCRIPTION
## Summary
- add RandomPosts React Native component to fetch and display posts
- document the component in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686bbe511a648329a14c608aac44591c